### PR TITLE
bump generic-pool to v3 and fix tests to match new api

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,27 +4,32 @@ const P = require('bluebird');
 
 const redis = require('@npmcorp/redis');
 
-module.exports = P.promisifyAll(require('generic-pool').Pool({
-  name: 'redis',
+module.exports = require('generic-pool').createPool({
+  create: function(){
+    return new P((resolve, reject) => {
+      const client = redis.createClient(process.env.REDIS_URL);
+      client.on('connect', function() {
+        client.removeListener('error', reject);
+        resolve(client);
+      });
+
+      client.once('error', reject);
+    })
+  },
+  destroy: function(client){
+    client.end()
+  }
+}, {
   max: 10,
   min: 1,
   idleTimeoutMillis: 30000,
-  create: function(cb) {
-    var client = redis.createClient(process.env.REDIS_URL);
-    client.on('connect', function() {
-      client.removeListener('error', cb);
-      cb(null, client);
-    });
-
-    client.on('error', cb);
-  },
-  destroy: function(client) {
-    client.end();
-  }
-}));
+  evictionRunIntervalMillis: 15000,
+  numTestsPerRun: 10,
+  Promise: P
+})
 
 module.exports.withConnection = function(liftedFn) {
-  var redisP = this.acquireAsync();
+  const redisP = this.acquire();
   return redisP.then(conn => {
     return redisP.then(liftedFn).finally(x => this.release(conn))
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@npmcorp/redis": "^1.0.0",
     "bluebird": "^3.4.1",
-    "generic-pool": "^2.4.2"
+    "generic-pool": "^3.1.4"
   },
   "devDependencies": {
     "redis-mock": "^0.16.0",

--- a/test/index.js
+++ b/test/index.js
@@ -10,21 +10,21 @@ const redisPool = requireInject.installGlobally('../', {
 });
 
 tap.test('redisPool releases a pool after a withConnection block', t => {
-  t.equal(redisPool.getPoolSize(), 1);
-  t.equal(redisPool.inUseObjectsCount(), 0); 
+  t.equal(redisPool.size, 1);
+  t.equal(redisPool.borrowed, 0); 
   return redisPool.withConnection(conn => {
     t.ok(conn);
-    t.equal(redisPool.getPoolSize(), 2);
+    t.ok(redisPool.size >= 1);
     return P.resolve()
       .then(() => {
-        t.equal(redisPool.getPoolSize(), 2);
-        t.equal(redisPool.inUseObjectsCount(), 1); 
+        t.ok(redisPool.size >= 1);
+        t.equal(redisPool.borrowed, 1); 
       });
   })
   .then(() => {
-    t.equal(redisPool.getPoolSize(), 2); 
-    t.equal(redisPool.inUseObjectsCount(), 0); 
-    redisPool.drainAsync().then(() => redisPool.destroyAllNow());
+    t.ok(redisPool.size >= 1); 
+    t.equal(redisPool.borrowed, 0); 
+    redisPool.drain().then(() => redisPool.clear());
   });
   
 });


### PR DESCRIPTION
Hi npm peeps.

Ended up doing this work as as part of seeing how difficult out upgrading generic-pool is for consumers. No idea if it's useful for you, but as it's done I thought I'd offer it up. Let me know if there is any more tidying up or changes that need making, or if it's not useful to you.

Code warning wise, generic-pool v3 requires node 4+, but I figured your probably running at least that!